### PR TITLE
add define to compile for ios simulator

### DIFF
--- a/SystemServices/Utilities/SSNetworkInfo.m
+++ b/SystemServices/Utilities/SSNetworkInfo.m
@@ -15,7 +15,11 @@
 #import <arpa/inet.h>
 
 // route
+#if TARGET_IPHONE_SIMULATOR
+#include <net/route.h>
+#else
 #include "route.h"
+#endif
 
 // sysctl
 #import <sys/sysctl.h>


### PR DESCRIPTION
this define avoid "redefinition of rt_XXXX" errors